### PR TITLE
Modify player icon logic

### DIFF
--- a/PM pacMacro2/MapViewController.swift
+++ b/PM pacMacro2/MapViewController.swift
@@ -128,14 +128,7 @@ class ViewController: UIViewController,
     func mapView(mapView: MGLMapView, imageForAnnotation annotation: MGLAnnotation) -> MGLAnnotationImage?{
         var imageName = "";
         if let iconType : String = annotation.subtitle! {
-            switch iconType {
-            case "Ghost":
-                imageName = "Ghost"
-            case "Pacman":
-                imageName = "Pacman"
-            default:
-                imageName = ""
-            }
+            imageName = iconType;
         }
         var annotationImage = mapView.dequeueReusableAnnotationImageWithIdentifier(imageName)
         let playerName : String = annotation.title!!

--- a/PM pacMacro2/MapViewController.swift
+++ b/PM pacMacro2/MapViewController.swift
@@ -127,6 +127,7 @@ class ViewController: UIViewController,
     /// Delegate function to set images for annotations. Will set the image based on the title of the annotation.
     func mapView(mapView: MGLMapView, imageForAnnotation annotation: MGLAnnotation) -> MGLAnnotationImage?{
         var imageName = "";
+        // Unwrap the annotation subtitle
         if let iconType : String = annotation.subtitle! {
             imageName = iconType;
         }


### PR DESCRIPTION
Simplify logic by removing the switch statement and replacing with direct assignment.

This assumes that the value of the annotation subtitle is one of the player types. Additional checks will be necessary upon assigning player type to ensure that player type is set correctly.
